### PR TITLE
Chapter 2: Use gitignored secrets.exs for Binance keys

### DIFF
--- a/02-create-trading-strategy.Rmd
+++ b/02-create-trading-strategy.Rmd
@@ -389,12 +389,33 @@ This creates a two-way link between the streamer and the naive app. In the next 
 
 ### Access details to Binance
 
-Inside the main config of our umbrella project we need to define access details for our Binance account:
+Inside the config of our umbrella project we create a new file `config/secrets.exs`. We will use this for our Binance account access details.
 
 ```{r, engine = 'elixir', eval = FALSE}
+# /config/secrets.exs
+import Config
+
 config :binance,
   api_key: "YOUR-API-KEY-HERE",
   secret_key: "YOUR-SECRET-KEY-HERE"
+```
+
+We don't want to check this file in, so we add it to our `.gitignore`:
+
+```{r, engine = 'bash', eval = FALSE}
+# .gitignore
+config/secrets.exs
+```
+
+Finally, we update our main config file to include it using [import_config](https://hexdocs.pm/elixir/master/Config.html#import_config/1):
+
+```{r, engine = 'elixir', eval = FALSE}
+# /config/config.exs
+
+# Import secrets file with Binance keys if it exists
+if File.exists?('config/secrets.exs') do
+  import_config('secrets.exs')
+end
 ```
 
 *Important note*: To be able to run the below test and perform real trades, a Binance account is required with a balance of at least 20 USDT. In the 4th chapter, we will focus on creating a `BinanceMock` that will allow us to run our bot *without* the requirement for a real Binance account. You don't need to test run it now if you don't need/want to have an account.


### PR DESCRIPTION
Updated:

This PR updates the section where we set the Binance API keys in order to avoid accidentally checking these keys into source control. We put the Binance config in a new `config/secrets.exs` which is added to `.gitignore` and included in `config/config.exs`if it exists using `import_config`. 

---

Originally:

I appreciate that this is maybe a bit opinionated, but I think it's worth showing a source-control-safe method of setting the keys for Binance. I'm following the book in a public repo and wouldn't want my keys in that repo. In this PR I'm using environment variables in `config/runtime.exs`. I've chosen to use `runtime.exs` in case the guide gets into compiling later on - compile time environment variable resolution is quite confusing/unexpected IMO. I've demonstrated setting these environment variables in the following test run.